### PR TITLE
[NO REVIEW] CI: Lfortran updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,26 +124,19 @@ jobs:
             container: intel/fortran-essentials:2025.2.0-0-devel-ubuntu24.04
 
           # --- LFortran coverage ---
+          # Formal now requires LFortran 0.64 or later
 
           # https://hub.docker.com/r/phhargrove/lfortran/tags
-          - os: ubuntu-24.04
-            compiler: lfortran
-            version: 0.61.0
-            container: phhargrove/lfortran:0.61.0-1
-          - os: ubuntu-24.04
-            compiler: lfortran
-            version: 0.62.0
-            container: phhargrove/lfortran:0.62.0-1
-          - os: ubuntu-24.04
-            compiler: lfortran
-            version: 0.63.0
-            container: phhargrove/lfortran:0.63.0-1
+          #- os: ubuntu-24.04
+          #  compiler: lfortran
+          #  version: 0.63.0
+          #  container: phhargrove/lfortran:0.64.0-1
 
           # https://github.com/lfortran/lfortran/pkgs/container/lfortran
-          - os: ubuntu-22.04
-            compiler: lfortran
-            version: 0.63.0
-            container: ghcr.io/lfortran/lfortran:v0.63.0
+          #- os: ubuntu-22.04
+          #  compiler: lfortran
+          #  version: 0.64.0
+          #  container: ghcr.io/lfortran/lfortran:v0.64.0
           - os: ubuntu-22.04
             compiler: lfortran
             version: latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,16 @@ defaults:
     shell: bash
 
 jobs:
+  setup: # This job currently just exists to reduce cancelled job spam in PRs
+    name: Ignore me
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve job concurrency
+        run: sleep 5
+
   build:
     name: ${{ matrix.compiler }}-${{ matrix.version }} (${{ matrix.os }})
+    needs: setup
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
Disables CI on older versions of LFortran, now that we intend to require 0.64 or later

Also adds a job step to reduce "cancelled job spam" in PRs opened from branches on the main repo (instead of a fork).

CC: @rouson 