### PR TITLE
CI: Disable gfortran and ifx

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,9 @@ jobs:
         version: [ 13, 14, 15 ] # Julienne supports GFortran 13+
         extra_flags: [ -g -O3 ]
 
+        exclude:
+          - compiler: gfortran  # gfortran disabled for now
+
         include:
 
           # --- LLVM flang coverage ---
@@ -90,33 +93,34 @@ jobs:
 
           # --- Intel coverage ---
           # Julienne requires 2025.2.0 or later
-
-          # https://hub.docker.com/r/intel/oneapi-toolkit/tags
-          - os: ubuntu-24.04
-            compiler: ifx
-            version: latest
-            container: intel/oneapi-toolkit:latest
-
-          - os: ubuntu-24.04
-            compiler: ifx
-            version: 2026.0.0
-            container: intel/oneapi-toolkit:2026.0.0-devel-ubuntu24.04
-
-          # https://hub.docker.com/r/intel/fortran-essentials/tags
-          - os: ubuntu-24.04
-            compiler: ifx
-            version: 2025.3.0
-            container: intel/fortran-essentials:2025.3.0-0-devel-ubuntu24.04
-
-          - os: ubuntu-24.04
-            compiler: ifx
-            version: 2025.2.2
-            container: intel/fortran-essentials:2025.2.2-0-devel-ubuntu24.04
-
-          - os: ubuntu-24.04
-            compiler: ifx
-            version: 2025.2.0
-            container: intel/fortran-essentials:2025.2.0-0-devel-ubuntu24.04
+          # ifx disabled for now
+#
+#          # https://hub.docker.com/r/intel/oneapi-toolkit/tags
+#          - os: ubuntu-24.04
+#            compiler: ifx
+#            version: latest
+#            container: intel/oneapi-toolkit:latest
+#
+#          - os: ubuntu-24.04
+#            compiler: ifx
+#            version: 2026.0.0
+#            container: intel/oneapi-toolkit:2026.0.0-devel-ubuntu24.04
+#
+#          # https://hub.docker.com/r/intel/fortran-essentials/tags
+#          - os: ubuntu-24.04
+#            compiler: ifx
+#            version: 2025.3.0
+#            container: intel/fortran-essentials:2025.3.0-0-devel-ubuntu24.04
+#
+#          - os: ubuntu-24.04
+#            compiler: ifx
+#            version: 2025.2.2
+#            container: intel/fortran-essentials:2025.2.2-0-devel-ubuntu24.04
+#
+#          - os: ubuntu-24.04
+#            compiler: ifx
+#            version: 2025.2.0
+#            container: intel/fortran-essentials:2025.2.0-0-devel-ubuntu24.04
 
           # --- LFortran coverage ---
           # Formal now requires LFortran 0.64 or later


### PR DESCRIPTION
@rouson Here is a quick and dirty disable of gfortran and ifx. 

This approach preserves the same basic YAML format as our other projects, to simplify CI maintenance. It also makes it very easy to re-enable these compilers if anything ever changes (or you want to re-test whether it has).

