### PR TITLE
[NO REVIEW] CI: Pin flang-latest testing to the newest non-broken container

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,11 +65,15 @@ jobs:
           - os: ubuntu-24.04
             compiler: flang
             version: latest
-            container: snowstep/llvm:noble
+            # pinned to old build due to https://github.com/kei-g/docker-llvm/issues/78
+            #container: snowstep/llvm:ubuntu-24.04-latest
+            container: snowstep/llvm:ubuntu-24.04-20260517082025
           - os: ubuntu-22.04
             compiler: flang
             version: latest
-            container: snowstep/llvm:jammy
+            # pinned to old build due to https://github.com/kei-g/docker-llvm/issues/78
+            #container: snowstep/llvm:ubuntu-22.04-latest
+            container: snowstep/llvm:ubuntu-22.04-20260528071927
 
           # https://hub.docker.com/r/phhargrove/llvm-flang/tags
           - os: ubuntu-24.04


### PR DESCRIPTION
The container we use for flang-latest testing is currently unusable:

https://github.com/kei-g/docker-llvm/issues/78

Pin CI to the last container tag that is not broken.