### PR TITLE
[NO REVIEW] CI: Add GFortran 16 coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
       matrix:
         os: [ macos-14, macos-15, macos-15-intel, macos-26, macos-26-intel, ubuntu-24.04 ]
         compiler: [ gfortran ]
-        version: [ 13, 14, 15 ] # Julienne supports GFortran 13+
+        version: [ 13, 14, 15, 16 ] # Julienne supports GFortran 13+
         extra_flags: [ -g -O3 ]
 
         exclude:
@@ -162,9 +162,9 @@ jobs:
       if: ${{ contains(matrix.os, 'ubuntu') && matrix.container == '' && matrix.compiler == 'gfortran' }}
       run: |
         sudo apt-get update
-        sudo apt list -a 'gfortran-*'
+        #sudo apt list -a 'gfortran-*'
         sudo apt install -y build-essential
-        if [[ ${COMPILER_VERSION} < 15 ]] ; then
+        if [[ ${COMPILER_VERSION} -lt 15 ]] ; then
           sudo apt install -y gfortran-${COMPILER_VERSION}
         else
           curl -L https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh -o install-homebrew.sh
@@ -200,6 +200,9 @@ jobs:
         brew update
         # fpm binary distribution for macOS requires gfortran shared libraries from gcc@12
         brew install gcc@12
+        if [[ ${{ matrix.compiler }} == 'gfortran' && ${COMPILER_VERSION} -gt 15 ]] ; then
+          brew install gcc@${COMPILER_VERSION}
+        fi
 
     - name: Install LLVM flang on macOS
       if: contains(matrix.os, 'macos') && matrix.compiler == 'flang'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,6 +171,7 @@ jobs:
           chmod +x install-homebrew.sh
           env CI=1 ./install-homebrew.sh
           HOMEBREW_PREFIX="/home/linuxbrew/.linuxbrew"
+          sudo ${HOMEBREW_PREFIX}/bin/brew setup-sandbox
           ${HOMEBREW_PREFIX}/bin/brew install -v gcc@${COMPILER_VERSION} binutils
           ls -al ${HOMEBREW_PREFIX}/bin
           echo "PATH=${HOMEBREW_PREFIX}/bin:${PATH}" >> "$GITHUB_ENV"
@@ -197,6 +198,8 @@ jobs:
     - name: Install macOS Dependencies
       if: contains(matrix.os, 'macos')
       run: |
+        # silence Homebrew tap trust warnings:
+        (set +e ; brew untap -f aws/tap hashicorp/tap 2>&1 | perl -pe 's/#*.warning./warn: /' ; brew trust azure/bicep )
         brew update
         # fpm binary distribution for macOS requires gfortran shared libraries from gcc@12
         brew install gcc@12

--- a/src/formal/tensors_2D_m.F90
+++ b/src/formal/tensors_2D_m.F90
@@ -187,7 +187,7 @@ module tensors_2D_m
     procedure, private, non_overridable :: divergence_2D_values
     procedure, private, non_overridable :: divergence_2D_grid
     procedure, private, non_overridable :: divergence_2D_to_file
-    procedure, private, non_overridable, private :: divergence_2D_postmultiply_constant
+    procedure, private, non_overridable :: divergence_2D_postmultiply_constant
     procedure, private, non_overridable, pass(rhs) :: divergence_2D_premultiply_constant
   end type
 


### PR DESCRIPTION
* Add GFortran 16 coverage to the CI infrastructure (Gfortran jobs remain disabled)
* Silence some nuisance warnings from Homebrew