### PR TITLE
Fix gradient_2D_t type's operator(*) binding

### DIFF
--- a/src/formal/gradient_2D_s.F90
+++ b/src/formal/gradient_2D_s.F90
@@ -29,14 +29,15 @@ contains
 
      call_julienne_assert(lhs%consistent())
 
-     !     points = [points_2D_t(lhs%points_(x_dir,1,1,1)%values_*rhs), points_2D_t(lhs%points_(y_dir,1,1,1)%values_*rhs)] &
-
-     associate(test_dummy => reshape([1],[1,1]))
-
      product%vector_2D_t = vector_2D_t( &
-        !tensor_2D_t( &
-        construct_2D_tensor_from_components( &
-           points = reshape([points_2D_t(test_dummy*rhs), points_2D_t(test_dummy*rhs)], shape=[space_dimension,1,1,1]) &
+        tensor_2D_t( &
+           points = reshape( &
+              source = [ &
+                 points_2D_t(lhs%points_(x_dir,1,1,1)%values_*rhs) &
+                ,points_2D_t(lhs%points_(y_dir,1,1,1)%values_*rhs) &
+              ] &
+             ,shape = [space_dimension,1,1,1] &
+           ) &
           ,cells = lhs%cells_ &
           ,x_min = lhs%x_min_ &
           ,x_max = lhs%x_max_ &
@@ -44,8 +45,6 @@ contains
         ) &
        ,divergence_operator_1D_t(k=lhs%order_, cells=lhs%cells_, dx=(lhs%x_max_ - lhs%x_min_)/lhs%cells_) &
      )
-
-     end associate
 
      call_julienne_assert(product%consistent())
 


### PR DESCRIPTION
This PR fixes the procedure definition corresponding to the gradient_2D_t type's operator(*) binding by replacing code that was used temporarily for debugging.